### PR TITLE
feat: Add Fly.io deployment configuration for ProductService

### DIFF
--- a/.github/workflows/fly_deploy_product_service.yml
+++ b/.github/workflows/fly_deploy_product_service.yml
@@ -1,0 +1,26 @@
+name: Deploy Product Service to Fly.io
+
+on:
+  push:
+    branches:
+      - main # Or your preferred deployment branch
+    paths: # Only run when ProductService or this workflow changes
+      - 'ProductService/**'
+      - '.github/workflows/fly_deploy_product_service.yml'
+
+jobs:
+  deploy:
+    name: Deploy Product Service
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Fly.io CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --remote-only
+        working-directory: ./ProductService/Product.API # Ensures flyctl uses the correct fly.toml

--- a/ProductService/Product.API/fly.toml
+++ b/ProductService/Product.API/fly.toml
@@ -1,0 +1,35 @@
+# fly.toml file generated for your-product-service-app-name
+#
+# Replace 'your-product-service-app-name' with your actual app name on Fly.io.
+app = "your-product-service-app-name"
+primary_region = "iad" # Example region, user can change as needed
+
+[build]
+  dockerfile = "Dockerfile" # Assumes Dockerfile is in the same directory as fly.toml
+  # You can add build arguments here if your Dockerfile needs them
+  # [build.args]
+  #   MY_ARG = "value"
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 8080 # ASP.NET Core default HTTP port in containers
+  processes = ["app"] # Matches the default process group
+
+  [[services.ports]]
+    port = 80 # External HTTP port
+  [[services.ports]]
+    port = 443 # External HTTPS port
+    handlers = ["tls", "http"]
+
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 25
+    soft_limit = 20
+
+  [[services.http_checks]]
+    interval = "10s"
+    timeout = "2s"
+    method = "GET"
+    path = "/healthz" # Assuming a standard health check endpoint, user might need to adjust
+    grace_period = "5s"
+    # To pass health checks an HTTP status code between 200 and 399 must be returned.


### PR DESCRIPTION
This commit introduces the necessary files to deploy the ProductService to Fly.io using GitHub Actions.

- Adds a `fly.toml` configuration file in `ProductService/Product.API/` which defines the application name (placeholder), build strategy (Dockerfile), and HTTP service details. The internal port is set to 8080, the default for ASP.NET Core applications in containers.

- Adds a GitHub Actions workflow in `.github/workflows/fly_deploy_product_service.yml`. This workflow triggers on pushes to the main branch (for changes in ProductService/** or the workflow file itself), sets up `flyctl`, and deploys the ProductService using the `FLY_API_TOKEN` secret. The deploy command uses `--remote-only` and specifies the working directory for ProductService.

You will need to create a Fly.io app, update the app name in `fly.toml`, and set the `FLY_API_TOKEN` secret in GitHub repository settings to enable deployment.